### PR TITLE
Add STM32F103 and STM32F107 CI configuration

### DIFF
--- a/.github/workflows/stm32f103.yml
+++ b/.github/workflows/stm32f103.yml
@@ -1,0 +1,32 @@
+name: STM32F103 CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-none-eabi
+
+    - name: Build project
+      run: |
+        make all
+        arm-none-eabi-objcopy -O ihex your_project.elf your_project.hex

--- a/.github/workflows/stm32f107.yml
+++ b/.github/workflows/stm32f107.yml
@@ -1,0 +1,32 @@
+name: STM32F107 CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-none-eabi
+
+    - name: Build project
+      run: |
+        make all
+        arm-none-eabi-objcopy -O ihex your_project.elf your_project.hex


### PR DESCRIPTION
Add GitHub Actions workflows for STM32F103 and STM32F107 development environments.

* **STM32F103 CI Workflow**
  - Add `.github/workflows/stm32f103.yml` file.
  - Configure workflow to trigger on push and pull request to the `main` branch.
  - Set up Python environment and install dependencies.
  - Build project and generate hex file.

* **STM32F107 CI Workflow**
  - Add `.github/workflows/stm32f107.yml` file.
  - Configure workflow to trigger on push and pull request to the `main` branch.
  - Set up Python environment and install dependencies.
  - Build project and generate hex file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Toveyrui/2025-writting-robot/pull/1?shareId=72557b43-06bb-4a4a-a7b2-55ad5cca89e5).